### PR TITLE
Clone to frozen Flashlight version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cd ..
 
 ### Install Flashlight
 ```
-git clone https://github.com/flashlight/flashlight.git
+git clone https://github.com/flashlight/flashlight.git --branch v0.3.2
 cd flashlight/bindings/python
 export USE_MKL=0
 python setup.py install


### PR DESCRIPTION
Flashlight has moved Python bindings for the beam search decoder to [Flashlight Text](https://github.com/flashlight/text) where they will be maintained and improved. While one can migrate build instructions to use those bindings, for now, fix the version of Flashlight to a version that precedes the decoder being moved.